### PR TITLE
Checkbox should act as uncontrolled input when `defaultChecked` and `checked` wasn't specified

### DIFF
--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -143,7 +143,7 @@ Checkbox.defaultProps = {
   variant: 'default',
   shadow: true,
   onChange: () => {},
-  checked: false,
+  checked: undefined,
   style: {},
   defaultChecked: false,
   className: ''

--- a/src/components/Checkbox/Checkbox.stories.js
+++ b/src/components/Checkbox/Checkbox.stories.js
@@ -15,12 +15,16 @@ storiesOf('Checkbox', module)
   .addDecorator(story => <Wrapper>{story()}</Wrapper>)
   .add('controlled group', () => <ControlledCheckboxGroupExample />)
   .add('uncontrolled', () => (
-    <Checkbox
-      name='single'
-      value='single'
-      label="I'm single 😥 ...and no one's controlling me 😎"
-      defaultChecked
-    />
+    <>
+      <Checkbox
+        name='cheese'
+        value='cheese'
+        label='Add extra cheese 🧀'
+        defaultChecked
+      />
+      <br />
+      <Checkbox name='pineapple' value='pineapple' label='Add pineapple 🍍' />
+    </>
   ))
   .add('flat', () => (
     <StyledCutout style={{ padding: '1rem', width: '300px' }}>


### PR DESCRIPTION
Checkbox should act as uncontrolled input when `defaultChecked` and `checked` wasn't specified. Currently Checkbox component didn't work in such situation