### PR TITLE
Move shadow definitions to theme to be able to have a flat one

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,4 +1,4 @@
-import "@storybook/addon-storysource/register";
-import "@storybook/addon-actions/register";
-import "@storybook/addon-links/register";
-import "storybook-addon-styled-component-theme/dist/src/register"; // v1.1.0^
+import '@storybook/addon-storysource/register';
+import '@storybook/addon-actions/register';
+import '@storybook/addon-links/register';
+import 'storybook-addon-styled-component-theme/dist/src/register'; // v1.1.0^

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,17 +1,18 @@
-import { configure, addDecorator } from "@storybook/react";
-import { withInfo } from "@storybook/addon-info";
-import { withThemesProvider } from "storybook-addon-styled-component-theme";
+import { configure, addDecorator } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import { withThemesProvider } from 'storybook-addon-styled-component-theme';
 
-import themes from "../src/components/common/themes";
+import themes from '../src/components/common/themes';
 
-import GlobalStyle from "./decorators/globalStyle";
+import GlobalStyle from './decorators/globalStyle';
 
 const demoThemes = [
   themes.default,
   themes.lilacRoseDark,
   themes.water,
   themes.coldGray,
-  themes.violetDark
+  themes.violetDark,
+  themes.flat
 ];
 
 addDecorator(
@@ -24,7 +25,7 @@ addDecorator(
       // Setting the style with a function
       ...stylesheet,
       table: {
-        background: "red"
+        background: 'red'
       }
     })
   })
@@ -32,7 +33,7 @@ addDecorator(
 addDecorator(GlobalStyle);
 addDecorator(withThemesProvider(demoThemes));
 
-const req = require.context("../src", true, /\.stories\.js$/);
+const req = require.context('../src', true, /\.stories\.js$/);
 function loadStories() {
   req.keys().forEach(filename => req(filename));
 }

--- a/.storybook/decorators/globalStyle.js
+++ b/.storybook/decorators/globalStyle.js
@@ -1,7 +1,7 @@
-import React from "react";
-import { createGlobalStyle } from "styled-components";
+import React from 'react';
+import { createGlobalStyle } from 'styled-components';
 
-import reset from "../../src/components/common/reset";
+import reset from '../../src/components/common/reset';
 
 const GlobalStyle = createGlobalStyle`
   ${reset}

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,11 +1,11 @@
 const path = require('path');
 
-module.exports = ({config}) => {
-    config.module.rules.push({
-        test: /\.stories\.js?$/,
-        loaders: [require.resolve('@storybook/addon-storysource/loader')],
-        enforce: 'pre',
-    });
+module.exports = ({ config }) => {
+  config.module.rules.push({
+    test: /\.stories\.js?$/,
+    loaders: [require.resolve('@storybook/addon-storysource/loader')],
+    enforce: 'pre'
+  });
 
-    return config;
+  return config;
 };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "lint": "eslint src --ext .js",
-    "lint:fix": "npm run lint -- --fix"
+    "lint:fix": "npm run lint -- --fix",
+    "prettier:check": "prettier --check \"{test,src,.storybook}/**/*.{js,jsx}\"",
+    "prettier:fix": "prettier --write \"{test,src,.storybook}/**/*.{js,jsx}\""
   },
   "peerDependencies": {
     "react": "^16.8.2",

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -59,8 +59,8 @@ const StyledCheckmark = styled(Cutout)`
   ${sharedCheckmarkStyles}
   background: ${({ theme, isDisabled }) =>
     isDisabled ? theme.material : theme.canvas};
-  box-shadow: ${({ shadow }) =>
-    shadow ? 'inset 3px 3px 10px rgba(0, 0, 0, 0.1)' : 'none'};
+  box-shadow: ${({ shadow, theme }) =>
+    shadow ? theme.insetShadowLight : 'none'};
   &:before {
     box-shadow: none;
   }

--- a/src/components/Cutout/Cutout.js
+++ b/src/components/Cutout/Cutout.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import styled from 'styled-components';
-import { insetShadow } from '../common';
 
 const StyledCutout = styled.div`
   position: relative;
@@ -32,7 +31,8 @@ const StyledCutout = styled.div`
     border-bottom-color: ${({ theme }) => theme.borderLight};
 
     pointer-events: none;
-    ${props => props.shadow && `box-shadow:${insetShadow};`}
+    ${({ shadow, theme }) =>
+      console.log(theme) || (shadow && `box-shadow:${theme.insetShadow};`)}
   }
 `;
 // add padding prop ?

--- a/src/components/Cutout/Cutout.js
+++ b/src/components/Cutout/Cutout.js
@@ -31,8 +31,7 @@ const StyledCutout = styled.div`
     border-bottom-color: ${({ theme }) => theme.borderLight};
 
     pointer-events: none;
-    ${({ shadow, theme }) =>
-      console.log(theme) || (shadow && `box-shadow:${theme.insetShadow};`)}
+    ${({ shadow, theme }) => shadow && `box-shadow:${theme.insetShadow};`}
   }
 `;
 // add padding prop ?

--- a/src/components/FileIcon/FileIcon.js
+++ b/src/components/FileIcon/FileIcon.js
@@ -7,16 +7,14 @@ import cx from 'classnames';
 
 import './FileIcon.css';
 
-const FileIcon = ({
-  imageURL, className, style, ...otherProps
-}) => {
+const FileIcon = ({ imageURL, className, style, ...otherProps }) => {
   const baseClass = 'FileIcon';
   const rootClass = cx(baseClass, className);
 
   return (
     <span className={rootClass} style={style} {...otherProps}>
       {imageURL && (
-        <img className={`${baseClass}__img`} src={imageURL} alt="icon" />
+        <img className={`${baseClass}__img`} src={imageURL} alt='icon' />
       )}
     </span>
   );
@@ -25,16 +23,13 @@ const FileIcon = ({
 FileIcon.defaultProps = {
   imageURL: null,
   className: '',
-  style: {},
+  style: {}
 };
 
 FileIcon.propTypes = {
   imageURL: propTypes.string,
   className: propTypes.string,
-  style: propTypes.shape([
-    propTypes.string,
-    propTypes.number,
-  ]),
+  style: propTypes.shape([propTypes.string, propTypes.number])
 };
 
 export default FileIcon;

--- a/src/components/Radio/Radio.js
+++ b/src/components/Radio/Radio.js
@@ -62,8 +62,8 @@ const StyledCheckmark = styled(Cutout)`
   background: ${({ theme, isDisabled }) =>
     isDisabled ? theme.material : theme.canvas};
 
-  box-shadow: ${({ shadow }) =>
-    shadow ? 'inset 3px 3px 10px rgba(0, 0, 0, 0.1)' : 'none'};
+  box-shadow: ${({ shadow, theme }) =>
+    shadow ? theme.insetShadowLight : 'none'};
 
   &:before {
     content: "";

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -4,7 +4,7 @@ import propTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import Button from '../Button/Button';
 
-import { shadow as commonShadow, createFlatBoxStyles } from '../common';
+import { createFlatBoxStyles } from '../common';
 import { blockSizes, fontSizes, padding } from '../common/system';
 import Cutout from '../Cutout/Cutout';
 
@@ -87,7 +87,8 @@ const StyledDropdownList = styled.ul`
           border: 2px solid ${({ theme }) => theme.flatDark};
         `
       : css`
-          box-shadow: ${props => (props.shadow ? commonShadow : 'none')};
+          box-shadow: ${({ shadow, theme }) =>
+            shadow ? theme.shadow : 'none'};
           bottom: -2px;
           width: calc(100% - 2px);
           border: 2px solid ${({ theme }) => theme.borderDarkest};

--- a/src/components/TableBody/TableBody.js
+++ b/src/components/TableBody/TableBody.js
@@ -2,12 +2,11 @@ import React from 'react';
 import propTypes from 'prop-types';
 
 import styled from 'styled-components';
-import { insetShadow } from '../common';
 
 const StyledTableBody = styled.tbody`
   background: ${({ theme }) => theme.canvas};
   display: table-row-group;
-  box-shadow: ${insetShadow};
+  box-shadow: ${({ theme }) => theme.insetShadow};
 `;
 
 const TableBody = ({ className, children, style, ...otherProps }) => (

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import propTypes from 'prop-types';
-
 import styled from 'styled-components';
-import { shadow } from '../common';
 
 const Tip = styled.span`
   position: absolute;
@@ -14,7 +12,7 @@ const Tip = styled.span`
   padding: 4px;
   border: 1px solid ${({ theme }) => theme.borderDarkest};
   background: ${({ theme }) => theme.tooltip};
-  box-shadow: ${shadow};
+  box-shadow: ${({ theme }) => theme.shadow};
   text-align: center;
 `;
 

--- a/src/components/common/index.js
+++ b/src/components/common/index.js
@@ -1,8 +1,5 @@
 import { css } from 'styled-components';
 
-export const shadow = '4px 4px 10px 0 rgba(0, 0, 0, 0.35)';
-export const insetShadow = 'inset 3px 3px 10px rgba(0, 0, 0, 0.2)';
-
 export const createDisabledTextStyles = () => css`
   color: ${({ theme }) => theme.textDisabled};
   text-shadow: 1px 1px ${({ theme }) => theme.textDisabledShadow};
@@ -36,8 +33,8 @@ export const createBorderStyles = (invert = false) =>
         border-top-color: ${({ theme }) => theme.borderDarkest};
         border-right-color: ${({ theme }) => theme.borderLightest};
         border-bottom-color: ${({ theme }) => theme.borderLightest};
-        box-shadow: ${props => props.shadow && `${shadow}, `} inset 1px 1px 0px
-            1px ${({ theme }) => theme.borderDark},
+        box-shadow: ${({ shadow, theme }) => shadow && `${theme.shadow}, `}
+            inset 1px 1px 0px 1px ${({ theme }) => theme.borderDark},
           inset -1px -1px 0 1px ${({ theme }) => theme.borderLight};
       `
     : css`
@@ -47,8 +44,8 @@ export const createBorderStyles = (invert = false) =>
         border-top-color: ${({ theme }) => theme.borderLightest};
         border-right-color: ${({ theme }) => theme.borderDarkest};
         border-bottom-color: ${({ theme }) => theme.borderDarkest};
-        box-shadow: ${props => props.shadow && `${shadow}, `} inset 1px 1px 0px
-            1px ${({ theme }) => theme.borderLight},
+        box-shadow: ${({ shadow, theme }) => shadow && `${theme.shadow}, `}
+            inset 1px 1px 0px 1px ${({ theme }) => theme.borderLight},
           inset -1px -1px 0 1px ${({ theme }) => theme.borderDark};
       `;
 export const createWellBorderStyles = (invert = false) =>

--- a/src/components/common/themes.js
+++ b/src/components/common/themes.js
@@ -1,6 +1,10 @@
 const themes = {};
 
 themes.default = {
+  shadow: '4px 4px 10px 0 rgba(0, 0, 0, 0.35)',
+  insetShadow: 'inset 3px 3px 10px rgba(0, 0, 0, 0.2)',
+  insetShadowLight: 'inset 3px 3px 10px rgba(0, 0, 0, 0.1)',
+
   hatchedBackground:
     'url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAIElEQVQYV2P8////fwYGBgZGRkZGMI0hABIFAbgEugAAQFQP/QfjEPcAAAAASUVORK5CYII=)',
 
@@ -41,6 +45,10 @@ themes.default = {
 };
 
 themes.water = {
+  shadow: '4px 4px 10px 0 rgba(0, 0, 0, 0.35)',
+  insetShadow: 'inset 3px 3px 10px rgba(0, 0, 0, 0.2)',
+  insetShadowLight: 'inset 3px 3px 10px rgba(0, 0, 0, 0.1)',
+
   hatchedBackground:
     'url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAIElEQVQYV2P8////fwYGBgZGRkZGMI0hABIFAbgEugAAQFQP/QfjEPcAAAAASUVORK5CYII=)',
 
@@ -81,6 +89,10 @@ themes.water = {
 };
 
 themes.coldGray = {
+  shadow: '4px 4px 10px 0 rgba(0, 0, 0, 0.35)',
+  insetShadow: 'inset 3px 3px 10px rgba(0, 0, 0, 0.2)',
+  insetShadowLight: 'inset 3px 3px 10px rgba(0, 0, 0, 0.1)',
+
   hatchedBackground:
     'url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAIElEQVQYV2P8////fwYGBgZGRkZGMI0hABIFAbgEugAAQFQP/QfjEPcAAAAASUVORK5CYII=)',
 
@@ -125,6 +137,10 @@ themes.coldGray = {
 };
 
 themes.lilacRoseDark = {
+  shadow: '4px 4px 10px 0 rgba(0, 0, 0, 0.35)',
+  insetShadow: 'inset 3px 3px 10px rgba(0, 0, 0, 0.2)',
+  insetShadowLight: 'inset 3px 3px 10px rgba(0, 0, 0, 0.1)',
+
   hatchedBackground:
     'url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAIElEQVQYV2P8////fwYGBgZGRkZGMI0hABIFAbgEugAAQFQP/QfjEPcAAAAASUVORK5CYII=)',
 
@@ -167,6 +183,10 @@ themes.lilacRoseDark = {
 };
 
 themes.violetDark = {
+  shadow: '4px 4px 10px 0 rgba(0, 0, 0, 0.35)',
+  insetShadow: 'inset 3px 3px 10px rgba(0, 0, 0, 0.2)',
+  insetShadowLight: 'inset 3px 3px 10px rgba(0, 0, 0, 0.1)',
+
   hatchedBackground:
     'url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAIElEQVQYV2P8////fwYGBgZGRkZGMI0hABIFAbgEugAAQFQP/QfjEPcAAAAASUVORK5CYII=)',
 
@@ -203,4 +223,6 @@ themes.violetDark = {
   flatLight: '#945b9b',
   flatDark: '#3c1f3e'
 };
+
+themes.flat = { ...themes.default, shadow: 'none', insetShadow: 'none' };
 export default themes;

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,13 +1,10 @@
-import React from 'react'
-import { ThemeProvider } from 'styled-components'
-import { render } from '@testing-library/react'
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import { render } from '@testing-library/react';
 
-import themes from '../src/components/common/themes'
+import themes from '../src/components/common/themes';
 
-export const theme = themes.default
+export const theme = themes.default;
 
-export const renderWithTheme = (component) => render(
-  <ThemeProvider theme={theme}>
-    {component}
-  </ThemeProvider>
-)
+export const renderWithTheme = component =>
+  render(<ThemeProvider theme={theme}>{component}</ThemeProvider>);


### PR DESCRIPTION
I love the library, great job! What I prefer not to have is shadows whatsoever to mimic 95 style even closer, so I moved the definitions to theme and created `themes.flat`, which is `default` with shadows off. I also fixed all prettier issues and add `package.json` scripts for it.