### PR TITLE
docs(cutout.mdx): fixed cutout component in docs

### DIFF
--- a/src/Cutout/Cutout.mdx
+++ b/src/Cutout/Cutout.mdx
@@ -6,8 +6,8 @@ menu: Components
 import { Playground, Props } from 'docz';
 
 import Cutout from './Cutout'
-import Window from '../Cutout/Cutout'
-import WindowContent from '../Cutout/Cutout'
+import Window from '../Window/Window'
+import WindowContent from '../WindowContent/WindowContent'
 
 # Cutout
 


### PR DESCRIPTION
Fixing imports in template of cutout component for docs

fix #192