### PR TITLE
fix(blocksizes): make block sizes even numbers

### DIFF
--- a/src/common/system.js
+++ b/src/common/system.js
@@ -2,7 +2,7 @@
 
 // eslint-disable-next-line import/prefer-default-export
 export const blockSizes = {
-  sm: '27px',
-  md: '35px',
-  lg: '43px'
+  sm: '28px',
+  md: '36px',
+  lg: '44px'
 };


### PR DESCRIPTION
making block sizes even to keep checkered background align nicely with borders