### PR TITLE
Provide node-friendly atob() fallback for better SSR support

### DIFF
--- a/src/common/index.js
+++ b/src/common/index.js
@@ -106,13 +106,16 @@ export const focusOutline = () => css`
   outline: 2px dotted ${({ theme }) => theme.materialText};
 `;
 
+const nodeBtoa = b => Buffer.from(b).toString('base64');
+const base64encode = typeof btoa !== 'undefined' ? btoa : nodeBtoa;
+
 const createTriangleSVG = (color, angle = 0) => {
   const svg = `<svg height="26" width="26" viewBox="0 0 26 26" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <g transform="rotate(${angle} 13 13)">
       <polygon fill="${color}" points="6,10 20,10 13,17"/>
     </g>
   </svg>`;
-  const encoded = window.btoa(svg);
+  const encoded = base64encode(svg);
   return `url(data:image/svg+xml;base64,${encoded})`;
 };
 


### PR DESCRIPTION
When `window` is undefined, react95 causes errors when server-side-rendering an app.

This PR provides a fallback for `window.atob` that uses node's `Buffer` to base64 the SVG instead.

---

<details>
<summary>I spent some time trying to switch to UTF-8 data URLs instead of base64, but ran into issues. Sharing that work here:</summary>

```js
const createTriangleSVG = (color, angle = 0) => {
  const escapedColor = color.replace('#', '%23');
  const svg = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 26 26'><g transform='rotate(${angle} 13 13)'><polygon fill='${escapedColor}' points='6,10 20,10 13,17'/></g></svg>`;
  return `url("data:image/svg+xml,${svg}")`;
};
```

In theory all of this should work! But what I am seeing is only the first URL works, the other images go missing.

![image](https://user-images.githubusercontent.com/405538/117558138-50c56f80-b02f-11eb-8789-6439ac314450.png)

Inspecting the rendered CSS we can see why:

```css
.gINYDX::-webkit-scrollbar-button:horizontal:decrement::-webkit-scrollbar-button:horizontal:increment{background-image:url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 26 26'><g transform='rotate(270 13 13)'><polygon fill='%230a0a0a' points='6,10 20,10 13,17'/></g></svg>");}
```

Looks like `.gINYDX::-webkit-scrollbar-button:horizontal:decrement::-webkit-scrollbar-button:horizontal:increment` is getting merged! This is likely a bug in styled-components; I stopped here and decided to just replace the `atob` function in node-land for now!

A commit was made on a separate branch, I may pick this up in the future. https://github.com/jdhartley/React95/commit/609a9af2b9c07ea503bb3e8be4bd8772fd60f667

</details>