### PR TITLE
fix(themes): use fitting desktop colors for remaining themes

### DIFF
--- a/src/common/themes/azureOrange.js
+++ b/src/common/themes/azureOrange.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#000000',
   checkmark: '#000000',
   checkmarkDisabled: '#05427f',
-  desktopBackground: '#008080',
+  desktopBackground: '#ff7d01',
   flatDark: '#9e9e9e',
   flatLight: '#d8d8d8',
   focusSecondary: '#171123',

--- a/src/common/themes/bee.js
+++ b/src/common/themes/bee.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#ffffff',
   checkmark: '#0C1618',
   checkmarkDisabled: '#846d06',
-  desktopBackground: '#008080',
+  desktopBackground: '#977800',
   flatDark: '#9e9e9e',
   flatLight: '#d8d8d8',
   focusSecondary: '#fefe03',

--- a/src/common/themes/candy.js
+++ b/src/common/themes/candy.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#EFF1F3',
   checkmark: '#000000',
   checkmarkDisabled: '#d1579e',
-  desktopBackground: '#008080',
+  desktopBackground: '#b477bd',
   flatDark: '#9e9e9e',
   flatLight: '#d8d8d8',
   focusSecondary: '#fefe03',

--- a/src/common/themes/coldGray.js
+++ b/src/common/themes/coldGray.js
@@ -15,7 +15,7 @@ export default {
   canvasTextInvert: '#ffffff',
   checkmark: '#010601',
   checkmarkDisabled: '#5b57a1',
-  desktopBackground: '#008080',
+  desktopBackground: '#606286',
   flatDark: '#5b57a1',
   flatLight: '#a4a7c8',
   focusSecondary: '#fefe03',

--- a/src/common/themes/counterStrike.js
+++ b/src/common/themes/counterStrike.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#f6fbf5',
   checkmark: '#f6fbf5',
   checkmarkDisabled: '#2c3125',
-  desktopBackground: '#008080',
+  desktopBackground: '#bcbd52',
   flatDark: '#9e9e9e',
   flatLight: '#d8d8d8',
   focusSecondary: '#fefe03',

--- a/src/common/themes/lilacRoseDark.js
+++ b/src/common/themes/lilacRoseDark.js
@@ -15,7 +15,7 @@ export default {
   canvasTextInvert: '#ecbfe3',
   checkmark: '#010601',
   checkmarkDisabled: '#7F3163',
-  desktopBackground: '#008080',
+  desktopBackground: '#663956',
   flatDark: '#7F3163',
   flatLight: '#E597C9',
   focusSecondary: '#fefe03',

--- a/src/common/themes/matrix.js
+++ b/src/common/themes/matrix.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#ffffff',
   checkmark: '#000000',
   checkmarkDisabled: '#282828',
-  desktopBackground: '#008080',
+  desktopBackground: '#000000',
   flatDark: '#9e9e9e',
   flatLight: '#d8d8d8',
   focusSecondary: '#35FF69',

--- a/src/common/themes/millenium.js
+++ b/src/common/themes/millenium.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#ffffff',
   checkmark: 'black',
   checkmarkDisabled: '#828282',
-  desktopBackground: '#008080',
+  desktopBackground: '#3a6ea5',
   flatDark: '#9e9e9e',
   flatLight: '#d8d8d8',
   focusSecondary: '#fefe03',

--- a/src/common/themes/modernDark.js
+++ b/src/common/themes/modernDark.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#202127',
   checkmark: '#000000',
   checkmarkDisabled: '#121317',
-  desktopBackground: '#008080',
+  desktopBackground: '#000000',
   flatDark: '#9e9e9e',
   flatLight: '#d8d8d8',
   focusSecondary: '#fefe03',

--- a/src/common/themes/molecule.js
+++ b/src/common/themes/molecule.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#f1f5f6',
   checkmark: '#020102',
   checkmarkDisabled: '#993845',
-  desktopBackground: '#008080',
+  desktopBackground: '#3a6ea5',
   flatDark: '#9e9e9e',
   flatLight: '#d8d8d8',
   focusSecondary: '#fefe03',

--- a/src/common/themes/ninjaTurtles.js
+++ b/src/common/themes/ninjaTurtles.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#000000',
   checkmark: '#000000',
   checkmarkDisabled: '#017401',
-  desktopBackground: '#008080',
+  desktopBackground: '#045424',
   flatDark: '#9e9e9e',
   flatLight: '#d8d8d8',
   focusSecondary: '#fefe03',

--- a/src/common/themes/olive.js
+++ b/src/common/themes/olive.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#000000',
   checkmark: '#000000',
   checkmarkDisabled: '#4f4c02',
-  desktopBackground: '#008080',
+  desktopBackground: '#666633',
   flatDark: '#9e9e9e',
   flatLight: '#d8d8d8',
   focusSecondary: '#000000',

--- a/src/common/themes/pamelaAnderson.js
+++ b/src/common/themes/pamelaAnderson.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#F1E4E8',
   checkmark: '#000000',
   checkmarkDisabled: '#7e0541',
-  desktopBackground: '#008080',
+  desktopBackground: '#000000',
   flatDark: '#9e9e9e',
   flatLight: '#d8d8d8',
   focusSecondary: '#fefe03',

--- a/src/common/themes/theSixtiesUSA.js
+++ b/src/common/themes/theSixtiesUSA.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#010001',
   checkmark: '#010001',
   checkmarkDisabled: '#6c1f71',
-  desktopBackground: '#008080',
+  desktopBackground: '#92458a', // original: #000000
   flatDark: '#d067d7',
   flatLight: '#df9be7',
   focusSecondary: '#fefe03',

--- a/src/common/themes/tokyoDark.js
+++ b/src/common/themes/tokyoDark.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#ffffff',
   checkmark: '#F4F4ED',
   checkmarkDisabled: '#1f2223',
-  desktopBackground: '#008080',
+  desktopBackground: '#181a1b',
   flatDark: '#9e9e9e',
   flatLight: '#d8d8d8',
   focusSecondary: '#20FC8F',

--- a/src/common/themes/tooSexy.js
+++ b/src/common/themes/tooSexy.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#ffffff',
   checkmark: '#000000',
   checkmarkDisabled: '#5a0302',
-  desktopBackground: '#008080',
+  desktopBackground: '#000000',
   flatDark: '#9e9e9e',
   flatLight: '#d8d8d8',
   focusSecondary: '#fefe03',

--- a/src/common/themes/travel.js
+++ b/src/common/themes/travel.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#ffffff',
   checkmark: '#28251e',
   checkmarkDisabled: '#695f50',
-  desktopBackground: '#008080',
+  desktopBackground: '#7c654c', // original: #000000
   flatDark: '#695f50',
   flatLight: '#9d8f80',
   focusSecondary: '#fefe03',

--- a/src/common/themes/vermillion.js
+++ b/src/common/themes/vermillion.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#EFE9F4',
   checkmark: '#130405',
   checkmarkDisabled: '#7f2120',
-  desktopBackground: '#008080',
+  desktopBackground: '#b22930',
   flatDark: '#9e9e9e',
   flatLight: '#d8d8d8',
   focusSecondary: '#fefe03',

--- a/src/common/themes/violetDark.js
+++ b/src/common/themes/violetDark.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#c57ece',
   checkmark: '#000000',
   checkmarkDisabled: '#3c1f3e',
-  desktopBackground: '#008080',
+  desktopBackground: '#3b1940',
   flatDark: '#3c1f3e',
   flatLight: '#945b9b',
   focusSecondary: '#fefe03',

--- a/src/common/themes/water.js
+++ b/src/common/themes/water.js
@@ -14,7 +14,7 @@ export default {
   canvasTextInvert: '#ffffff',
   checkmark: '#050608',
   checkmarkDisabled: '#888c8f',
-  desktopBackground: '#008080',
+  desktopBackground: '#3a6ea5',
   flatDark: '#9e9e9e',
   flatLight: '#d8d8d8',
   focusSecondary: '#fefe03',


### PR DESCRIPTION
Continues the work of #238. The remaining themes now use a hand-picked desktop background color that matches the existing colors and spirit of the theme.

For `theSixtiesUSA` and `travel`, the two themes that originate from the Windows 98 Plus! pack, colors based on the original wallpaper were chosen. The original themes themselves specify full black as the desktop background, supposedly with the assumption that the included wallpaper would be used, making the background color irrelevant.

`coldGray` and `lilacRoseDark` appear similar to themes published at [Mochinet](https://www.mochinet.com/Themes/), but they do not appear to be the same themes. New colors were chosen instead of taking from the Mochinet themes since the Mochinet themes are low contrast, whereas the React95 themes are not.

Closes #223 