### PR TITLE
chore(lint): add eslint-plugin-react-hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,8 @@ module.exports = {
   extends: [
     'plugin:@typescript-eslint/recommended',
     'airbnb',
-    'plugin:prettier/recommended'
+    'plugin:prettier/recommended',
+    'plugin:react-hooks/recommended'
   ],
   parser: '@typescript-eslint/parser',
   plugins: ['react', 'prettier'],
@@ -32,6 +33,7 @@ module.exports = {
     'import/prefer-default-export': 'off',
     'jsx-a11y/label-has-associated-control': ['error', { assert: 'either' }],
     'jsx-a11y/label-has-for': 'off',
+    'no-nested-ternary': 'off',
     'prettier/prettier': 'error',
     'react/forbid-prop-types': 'off',
     'react/jsx-filename-extension': [

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "eslint-plugin-jsx-a11y": "^6.6.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.30.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "firebase-tools": "^11.3.0",
     "husky": "^8.0.1",
     "jest": "^28.1.3",

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-nested-ternary */
-
 import React, { forwardRef } from 'react';
 import styled, { css } from 'styled-components';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7173,6 +7173,11 @@ eslint-plugin-prettier@^4.2.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
+  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
+
 eslint-plugin-react@^7.30.1:
   version "7.30.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.30.1.tgz#2be4ab23ce09b5949c6631413ba64b2810fd3e22"


### PR DESCRIPTION
This is very useful to make sure hooks are implemented properly, and to help fill hooks dependency arrays.

This also disables no-undef for TypeScript files and removes no-nested-ternary.
