### PR TITLE
build(themes): add manual fix for themes .d.ts build problem

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import esbuild from 'rollup-plugin-esbuild';
 import copy from 'rollup-plugin-copy';
 import dts from 'rollup-plugin-dts';
 import replace from 'rollup-plugin-replace';
+import fixThemesDts from './rollup.plugin.fixthemesdts';
 import packageJson from './package.json';
 
 const NODE_ENV = process.env.NODE_ENV || 'development';
@@ -32,7 +33,10 @@ const bundle = config => [
       replace({
         'process.env.NODE_ENV': JSON.stringify(NODE_ENV)
       }),
-      dts()
+      dts(),
+      fixThemesDts({
+        themesDtsFileName: 'common/themes/index.d.ts'
+      })
     ]
   }
 ];

--- a/rollup.plugin.fixthemesdts.js
+++ b/rollup.plugin.fixthemesdts.js
@@ -1,0 +1,31 @@
+/* eslint-disable no-await-in-loop, no-restricted-syntax */
+
+import { renameSync } from 'fs';
+import { resolve } from 'path';
+
+const plugin = ({ themesDtsFileName } = {}) => {
+  return {
+    name: 'fix-themes-dts',
+    renderChunk: async (code, chunk, options) => {
+      if (
+        themesDtsFileName &&
+        options.dir &&
+        chunk.fileName === themesDtsFileName
+      ) {
+        return code.replace('../../types.js', './types.d');
+      }
+
+      return null;
+    },
+    writeBundle: async (options, bundles) => {
+      if (themesDtsFileName && options.dir && bundles[themesDtsFileName]) {
+        renameSync(
+          resolve(options.dir, themesDtsFileName),
+          resolve(options.dir, './index.d.ts')
+        );
+      }
+    }
+  };
+};
+
+export default plugin;


### PR DESCRIPTION
It seems https://github.com/Swatinem/rollup-plugin-dts doesn't play nicely when using Rollup's `dir` output option.

This is a proposed hack as a plugin that corrects the code (given there is a broken import) and manually moves the file.