### PR TITLE
build(debug): patch dependencies to log intermittent issues with build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,67 +1,6 @@
 {
-  "sourceType": "unambiguous",
   "presets": [
-    [
-      "@babel/preset-env",
-      {
-        "shippedProposals": true,
-        "loose": true
-      }
-    ],
+    "@babel/preset-env",
     "@babel/preset-typescript"
-  ],
-  "plugins": [
-    "@babel/plugin-transform-shorthand-properties",
-    "@babel/plugin-transform-block-scoping",
-    [
-      "@babel/plugin-proposal-decorators",
-      {
-        "legacy": true
-      }
-    ],
-    [
-      "@babel/plugin-proposal-class-properties",
-      {
-        "loose": true
-      }
-    ],
-    [
-      "@babel/plugin-proposal-private-property-in-object",
-      {
-        "loose": true
-      }
-    ],
-    [
-      "@babel/plugin-proposal-private-methods",
-      {
-        "loose": true
-      }
-    ],
-    "@babel/plugin-proposal-export-default-from",
-    "@babel/plugin-syntax-dynamic-import",
-    [
-      "@babel/plugin-proposal-object-rest-spread",
-      {
-        "loose": true,
-        "useBuiltIns": true
-      }
-    ],
-    "@babel/plugin-transform-classes",
-    "@babel/plugin-transform-arrow-functions",
-    "@babel/plugin-transform-parameters",
-    "@babel/plugin-transform-destructuring",
-    "@babel/plugin-transform-spread",
-    "@babel/plugin-transform-for-of",
-    "babel-plugin-macros",
-    "@babel/plugin-proposal-optional-chaining",
-    "@babel/plugin-proposal-nullish-coalescing-operator",
-    [
-      "babel-plugin-polyfill-corejs3",
-      {
-        "method": "usage-global",
-        "absoluteImports": "core-js",
-        "version": "3.24.1"
-      }
-    ]
   ]
 }

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -21,9 +21,6 @@ const storybookConfig: StorybookConfig = {
     builder: 'webpack5'
   },
   features: {
-    babelModeV7: true,
-    storyStoreV7: true,
-    modernInlineRender: true,
     postcss: false
   },
   typescript: {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "start": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true start-storybook -p 9009",
-    "build:storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true build-storybook -o ./storybook",
+    "build:storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true build-storybook -o ./storybook --loglevel silly --debug-webpack",
     "build": "rm -rf dist && yarn run build:prod",
     "build:dev": "cross-env NODE_ENV=development rollup -c",
     "build:prod": "cross-env NODE_ENV=production rollup -c",
@@ -46,7 +46,8 @@
     "lint": "eslint --ext .js,.ts,.tsx src",
     "lint:fix": "yarn run lint --fix",
     "semantic-release": "semantic-release",
-    "cz": "git-cz"
+    "cz": "git-cz",
+    "postinstall": "patch-package"
   },
   "peerDependencies": {
     "react": ">= 16.8.0",
@@ -108,6 +109,8 @@
     "jest-environment-jsdom": "^28.1.3",
     "jest-styled-components": "^7.0.8",
     "lint-staged": "^13.0.3",
+    "patch-package": "^6.4.7",
+    "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.7.1",
     "react": "^17.0.2",
     "react-docgen-typescript": "^2.2.2",

--- a/patches/@storybook+builder-webpack5+6.5.10.patch
+++ b/patches/@storybook+builder-webpack5+6.5.10.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@storybook/builder-webpack5/dist/cjs/index.js b/node_modules/@storybook/builder-webpack5/dist/cjs/index.js
+index 1037f48..0ee4bcf 100644
+--- a/node_modules/@storybook/builder-webpack5/dist/cjs/index.js
++++ b/node_modules/@storybook/builder-webpack5/dist/cjs/index.js
+@@ -231,6 +231,8 @@ var builder = async function* builderGeneratorFn({
+             return _nodeLogger.logger.error(e.message);
+           });
+           compiler.close(function () {
++            console.log(config)
++            console.trace('webpack failed')
+             return options.debugWebpack ? fail(stats) : fail(new Error('=> Webpack failed, learn more with --debug-webpack'));
+           });
+           return;

--- a/patches/@storybook+manager-webpack5+6.5.10.patch
+++ b/patches/@storybook+manager-webpack5+6.5.10.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/@storybook/manager-webpack5/dist/cjs/index.js b/node_modules/@storybook/manager-webpack5/dist/cjs/index.js
+index c1d7fda..40006a0 100644
+--- a/node_modules/@storybook/manager-webpack5/dist/cjs/index.js
++++ b/node_modules/@storybook/manager-webpack5/dist/cjs/index.js
+@@ -573,6 +573,10 @@ var builder = /*#__PURE__*/function () {
+             return;
+ 
+           case 12:
++            if (config.entry && config.entry.some(entry => entry === undefined)) {
++              console.log(config)
++              console.trace('undefined found in entry!')
++            }
+             compiler = webpackInstance(config);
+ 
+             if (compiler) {

--- a/patches/babel-plugin-polyfill-corejs3+0.5.3.patch
+++ b/patches/babel-plugin-polyfill-corejs3+0.5.3.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/babel-plugin-polyfill-corejs3/esm/index.mjs b/node_modules/babel-plugin-polyfill-corejs3/esm/index.mjs
+index 2819a9c..ab56032 100644
+--- a/node_modules/babel-plugin-polyfill-corejs3/esm/index.mjs
++++ b/node_modules/babel-plugin-polyfill-corejs3/esm/index.mjs
+@@ -475,6 +475,10 @@ var index = defineProvider(function ({
+     static: StaticProperties,
+     instance: InstanceProperties
+   });
++  if (typeof getModulesListForTargetVersion !== 'function') {
++    console.log(getModulesListForTargetVersion)
++    console.trace('getModulesListForTargetVersion is not a function')
++  }
+   const available = new Set(getModulesListForTargetVersion(version));
+ 
+   function getCoreJSPureBase(useProposalBase) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3820,6 +3820,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -5268,7 +5273,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.3.2, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -7969,6 +7974,13 @@ find-versions@^4.0.0:
   dependencies:
     semver-regex "^3.1.2"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 findup-sync@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-4.0.0.tgz#956c9cdde804052b881b428512905c4a5f2cdef0"
@@ -8216,6 +8228,15 @@ fs-extra@^10.0.0, fs-extra@^10.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^2.0.0"
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-extra@^8.1.0:
   version "8.1.0"
@@ -10827,6 +10848,13 @@ kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 klaw@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-3.0.0.tgz#b11bec9cf2492f06756d6e809ab73a2910259146"
@@ -12606,7 +12634,7 @@ open@^6.3.0:
   dependencies:
     is-wsl "^1.1.0"
 
-open@^7.0.3:
+open@^7.0.3, open@^7.4.2:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
   integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
@@ -13013,6 +13041,25 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==
 
+patch-package@^6.4.7:
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.4.7.tgz#2282d53c397909a0d9ef92dae3fdeb558382b148"
+  integrity sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+
 path-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
@@ -13329,6 +13376,11 @@ postcss@^8.2.15:
     nanoid "^3.3.4"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+postinstall-postinstall@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
+  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
This patches `@storybook/builder-webpack5`, `@storybook/manager-webpack5` and `babel-plugin-polyfill-corejs3` to log information so we can debug why it is intermittently failing on GitHub CI.