### PR TITLE
refactor(anchor): add underline property, default true

### DIFF
--- a/src/Anchor/Anchor.tsx
+++ b/src/Anchor/Anchor.tsx
@@ -5,22 +5,23 @@ import { CommonStyledProps } from '../types';
 
 type AnchorProps = {
   children: React.ReactNode;
+  underline?: boolean;
 } & React.AnchorHTMLAttributes<HTMLAnchorElement> &
   CommonStyledProps;
 
 const StyledAnchor = styled.a<{ underline: boolean }>`
   color: ${({ theme }) => theme.anchor};
   font-size: inherit;
-  text-decoration: underline;
+  text-decoration: ${({ underline }) => (underline ? 'underline' : 'none')};
   &:visited {
     color: ${({ theme }) => theme.anchorVisited};
   }
 `;
 
 const Anchor = forwardRef<HTMLAnchorElement, AnchorProps>(
-  ({ children, ...otherProps }: AnchorProps, ref) => {
+  ({ children, underline = true, ...otherProps }: AnchorProps, ref) => {
     return (
-      <StyledAnchor ref={ref} {...otherProps}>
+      <StyledAnchor ref={ref} underline={underline} {...otherProps}>
         {children}
       </StyledAnchor>
     );


### PR DESCRIPTION
This aligns the component with react95-native.

Note: this commit includes changes from #332, given that was opened in a fork. It should be rebased once that is merged.