### PR TITLE
build: remove babel-plugin-polyfill-corejs3 to avoid Babel issue building Storybook

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -54,14 +54,6 @@
     "@babel/plugin-transform-for-of",
     "babel-plugin-macros",
     "@babel/plugin-proposal-optional-chaining",
-    "@babel/plugin-proposal-nullish-coalescing-operator",
-    [
-      "babel-plugin-polyfill-corejs3",
-      {
-        "method": "usage-global",
-        "absoluteImports": "core-js",
-        "version": "3.24.1"
-      }
-    ]
+    "@babel/plugin-proposal-nullish-coalescing-operator"
   ]
 }


### PR DESCRIPTION
The build error happens inside that plugin, which shouldn't be necessary in modern browsers.