### PR TITLE
fix(coverage): fix Jest coverage not properly referencing code points correctly

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,13 +1,12 @@
 module.exports = {
   globals: {
-    extensionsToTreatAsEsm: ['.js'],
     'ts-jest': {
       diagnostics: false,
-      isolatedModules: true,
-      useESM: true
+      isolatedModules: true
     }
   },
-  preset: 'ts-jest/presets/js-with-ts-esm',
+  coverageReporters: ['text', 'html'],
+  preset: 'ts-jest/presets/default-esm',
   setupFilesAfterEnv: ['<rootDir>/test/setup-test.ts'],
   testEnvironment: 'jsdom'
 };

--- a/tsconfig.build.index.json
+++ b/tsconfig.build.index.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": true,
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "sourceMap": false
   },
   "include": [
     "types/global.d.ts",

--- a/tsconfig.build.themes.json
+++ b/tsconfig.build.themes.json
@@ -4,6 +4,7 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist/themes",
     "rootDir": "./src/common/themes",
+    "sourceMap": false
   },
   "include": [
     "src/common/themes/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,7 @@
     "resolveJsonModule": true,
     "rootDir": "./",
     "skipLibCheck": true,
-    "sourceMap": false,
+    "sourceMap": true,
     "strict": true,
     "strictFunctionTypes": true,
     "strictNullChecks": true,


### PR DESCRIPTION
Code coverage depends on TypeScript sourceMap, which we disabled for builds.